### PR TITLE
Fix url params

### DIFF
--- a/setup-pipeline.sh
+++ b/setup-pipeline.sh
@@ -9,7 +9,7 @@ curl --fail -s -H "Authorization: Bearer $BUILDKITE_TOKEN" -XPOST \
 
 # YEAS, THIS IS CRAP BUT YEAH WATF
 curl --fail -s -H "Authorization: Bearer $BUILDKITE_TOKEN" -XPATCH \
-	"https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}" \
+	"https://api.buildkite.com/v2/organizations/$org/pipelines/$repo" \
 	-d @<(sed -e "s/\$org/$org/g" -e "s/\$repo/$repo/g" pipeline.json)
 
 echo "~~~ Setting up webhooks"
@@ -18,6 +18,7 @@ url="$(
 		"https://api.buildkite.com/v2/organizations/$org/pipelines/$repo" |
 		jq -r '.provider.webhook_url'
 )"
+
 curl --fail -s -H "Authorization: token $GITHUB_TOKEN" -XPOST \
 	"https://api.github.com/repos/$org/$repo/hooks" \
 	-d @<(sed "s#\$url#$url#" webhook.json)


### PR DESCRIPTION
The script is trying to call this url: `PATCH /v2/organizations/org.slug/pipelines/slug` but it doesn't exist returning a 404.

Fixed the url to use the script parameters like the first curl.

@caarlos0 