### PR TITLE
restrict the builds to master branch and pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Wiring buildkite pipelines to github repos with a single script
 
 ## What it does?
 
-1. Creates a pipeline in Builkite that reads for steps on the repo, 
-build PR from 3rd parties and publish commit status;
+1. Creates a pipeline in Builkite that reads for steps on the repo and build only:
+   - Commits from master branch;
+   - And all PRs, including 3rd parties, then publish commit status;
 1. Adds the right Buildkite webhook on the github repo.
 
 ## Assumptions

--- a/pipeline.json
+++ b/pipeline.json
@@ -10,7 +10,7 @@
     }
   ],
   "default_branch": "master",
-  "branch_configuration": "master this-will-never-exist",
+  "branch_configuration": "master",
   "provider_settings": {
     "trigger_mode": "code",
     "repository": "$org/$repo",

--- a/pipeline.json
+++ b/pipeline.json
@@ -9,17 +9,21 @@
       "command": "buildkite-agent pipeline upload"
     }
   ],
+  "default_branch": "master",
+  "branch_configuration": "master this-will-never-exist",
   "provider_settings": {
     "trigger_mode": "code",
+    "repository": "$org/$repo",
+    "build_tags": false,
     "build_pull_requests": true,
-    "pull_request_branch_filter_enabled": false,
-    "skip_pull_request_builds_for_existing_commits": true,
+    "pull_request_branch_filter_enabled": true,
+    "pull_request_branch_filter_configuration": "",
     "build_pull_request_forks": true,
     "prefix_pull_request_fork_branch_names": true,
-    "build_tags": true,
+    "skip_pull_request_builds_for_existing_commits": true,
     "publish_commit_status": true,
     "publish_commit_status_per_step": false,
-    "repository": "$org/$repo",
-    "pull_request_branch_filter_configuration": ""
+    "publish_blocked_as_pending": true,
+    "separate_pull_request_statuses": false
   }
 }


### PR DESCRIPTION
## Cenário atual
Toda vez que é feito um push para o repo, original ou fork, o build é iniciado.
Em seguida, quando um PR é aberto em cima desse novo commit, o buildkite "reaproveita" o build que já foi executado.

##  Problema
Com a introdução do sonarqube, isso passou a ser um problema.

É um problema porque o sonar precisa do número do PR para poder reportar o resultado da análise de código. Como o build foi iniciado antes de ser aberto o PR, não existe um número de PR disponível, logo, o sonar não tem onde reportar as issues.

## Alterações
Com as alterações propostas nesse PR esse problema deixa de existir porque o build será executado somente quando um PR for aberto ou quando um commit cair na master.

Isso ainda tem o impacto de reduzir drasticamente a quantidade de builds executados, porque irá buildar somente commits relevantes (que fazem parte de um PR ou da master) e deixará de buildar commits que nunca vão ser integrados na master do projeto (commits de test/backup de forks por exemplo).

E os builds de commits da master, garantem que os códigos que, potencialmente, vão para prod, sejam analisados e reportados para o Dashboard do SonarQube, sendo possível ver a evolução do sistema.

Epic: https://github.com/ContaAzul/dev-x/issues/146